### PR TITLE
1.4.0 - remove info and human readable time fields from /local/ PUT

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,37 +16,41 @@ api_description = """
 
 ## Local
 
-You can **`GET /local`**'s data:
+You can **`GET /local/`**'s data:
 * **Door state** (`"door_state" : int`)  
     0 = closed, 1 = open, 2 = unknown  
     _The door state is unknown when the last update was too long ago (more than 5 minutes), meaning a problem occured with the door status system._
 * **Door update time** (`"update_time" : str`)  
     Human readable
 * **Info** (`"info" : str`)  
-    Info about the local or door
+    Info about the Local or door
 * **Temperature** (`"temperature" : int`)  
     In °C
 * **Humidity** (`"humidity" : int`)  
     In %
 * **Door update time (UNIX)** (`"update_time_unix" : int`)  
-    Epoch time, seconds since 1970-01-01 00:00:00 UTC(+1)  
-    ⚠️ this has an offset of UTC+1 applied (so +3600 compared to true UNIX time(UTC))
+    Epoch time, seconds since 1970-01-01 00:00:00 UTC
+
+## Info (about BEP or Local)
+
+You can **`GET /info/`**'s data:
+* **Info** (`"info" : str`)  
+    Info about the Local or door
 
 ## Door (in Local)
 
-You can **`GET /door`**'s data:
+You can **`GET /door/`**'s data:
 * **Door state** (`"door_state" : int`)  
     0 = closed, 1 = open, 2 = unknown  
     _The door state is unknown when the last update was too long ago (more than 5 minutes), meaning a problem occured with the door status system._
 * **Door update time** (`"update_time" : str`)  
     Human readable
 * **Door update time (UNIX)** (`"update_time_unix" : int`)  
-    Epoch time, seconds since 1970-01-01 00:00:00 UTC(+1)  
-    ⚠️ this has an offset of UTC+1 applied (so +3600 compared to true UNIX time(UTC))
+    Epoch time, seconds since 1970-01-01 00:00:00 UTC
 
 ## Temperature and humidity (in Local)
 
-You can **`GET /temp`** data:
+You can **`GET /temp/`** data:
 * **Temperature** (`"temperature" : int`)
     In °C
 * **Humidity** (`"humidity" : int`)
@@ -56,14 +60,19 @@ You can **`GET /temp`** data:
 BEP website: [bepolytech.be](http://bepolytech.be/)  
 
 > *Notes:*
-> - **`PUT /local`** requires a private API key, reserved for BEP.  
+> - **`PUT /local/`** requires a private API key, reserved for BEP.  
+> - **`PUT /info/`** requires a private API key, reserved for BEP.  
 > - Any request to non-existent endpoints will return `{"detail": "Not Found"}`.
 """
 
 tags_metadata = [
     {
         "name": "local",
-        "description": "Operations with the BEP's Local data.",
+        "description": "Info and operations with the BEP's Local data.",
+    },
+    {
+        "name": "info",
+        "description": "Info about BEP or its Local.",
     },
     {
         "name": "door",
@@ -84,7 +93,7 @@ limiter = Limiter(key_func=get_remote_address, headers_enabled=False, default_li
 app = FastAPI(
     title="BEP API - BEPI",
     description=api_description,
-    version="1.3.0",
+    version="1.4.0",
     contact={
         "name": "BEP - Bureau Étudiant de Polytechnique",
         "url": "http://bepolytech.be/",

--- a/app/main.py
+++ b/app/main.py
@@ -175,11 +175,11 @@ async def read_local(request: Request) -> dict:
 # request argument must be explicitly passed to your endpoint, or slowapi won't be able to hook into it :
 def update_local(*, request: Request,
         door_state: int = 2,
-        info: str = "No info",
-        update_time: str = "No time",
+        #info: str = "No info",
+        #update_time: str = "No time",
         update_time_unix: int,
         temperature: int = 69,
-        humidity: int = 420
+        humidity: int = 69
     ) -> dict:
 
     #origin_ip=""
@@ -193,9 +193,10 @@ def update_local(*, request: Request,
     #        print("No x-forwarded-for header found")
     #print("PUT request at /local/ from " + str(origin_ip))
     print("PUT request at /local/")
-    if local.updateDoorStateTime(update_time, update_time_unix):
+    #if local.updateDoorStateTime(update_time, update_time_unix):
+    if local.updateDoorStateTime(update_time_unix):
         local.updateDoorStatus(door_state)
-        local.updateInfo(info)
+        #local.updateInfo(info)
         local.updateTempandHum(temperature, humidity)
         print("Local update PUT request successfully processed")
         res = {"api_key": "correct", "auth": "yes", "update": "success"}
@@ -207,6 +208,46 @@ def update_local(*, request: Request,
     print("Sending response:")
     print(res)
     return res
+
+
+@app.get("/info/", tags=["info"])
+@limiter.limit("120/minute")  # 120 requests per minute = 2 requests per second
+# request argument must be explicitly passed to your endpoint, or slowapi won't be able to hook into it :
+async def read_info(request: Request) -> dict:
+    # origin_ip = ""
+    # print("Analyzing request headers for x-forwarded-for:")
+    # for header in request.headers.raw:
+    #    if header[0] == 'x-forwarded-for'.encode('utf-8'):
+    #        origin_ip, forward_ip = re.split(', ', header[1].decode('utf-8'))
+    #        print(f"origin_ip:\t{origin_ip}")
+    #        print(f"forward_ip:\t{forward_ip}")
+    #    else:
+    #        print("No x-forwarded-for header found")
+    # print("GET request at /local/ from " + str(origin_ip))
+    print("GET request at /info/")
+    info = local.getInfo()
+    res = {"info": info}
+    print("Sending response:")
+    print(res)
+    return res
+
+
+@app.put("/info/", dependencies=[Depends(auth.get_api_key)], tags=["info"])
+@limiter.limit("300/minute")  # 300 requests per minute = 5 requests per second
+# request argument must be explicitly passed to your endpoint, or slowapi won't be able to hook into it :
+def update_info(*, request: Request,
+                 info: str = "No info"
+                 ) -> dict:
+    print("PUT request at /info/")
+    try:
+        local.updateInfo(info)
+        print("Info update PUT request successfully processed")
+        res = {"api_key": "correct", "auth": "yes", "update": "success"}
+    except:
+        print("Info update PUT request process failed")
+        res = {"api_key": "correct", "auth": "yes", "update": "failed", "detail": "info update failed"}
+    finally:
+        return res
 
 
 # -- Door status -- #


### PR DESCRIPTION
- BREAKING: remove info and update_time (human readable time) fields from PUT /local/.
- update_time (human readable) is calculated and formatted by the server.
- add PUT (requires api_token) and GET /info/.
- BREAKING: remove offset from unix time on update from ESP8266, no more offset epoch time stored and sent.